### PR TITLE
Add structures to decode jaeger thrift requests into sapm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # IDEs
 .idea/
+
+# Test coverage output
+coverage.out.all

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export GO111MODULE = on
 
 # default is verification of sfxinternalgo which includes all services
 .PHONY: verify
-verify: install-tools test
+verify: install-tools lint test
 
 # Tools that package is dependent on
 .PHONY: install-tools

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func TestParseForwardTimeout(t *testing.T) {
 	config, err := decodeConfig([]byte(`{"ForwardTo":[{"Timeout":"3s"}]}`))
 	assert.Nil(t, err)
 	assert.Equal(t, *config.ForwardTo[0].TimeoutDuration, time.Second*3)
-	config, err = decodeConfig([]byte(`{"ForwardTo":[{"Timeout":"3r"}]}`))
+	_, err = decodeConfig([]byte(`{"ForwardTo":[{"Timeout":"3r"}]}`))
 	assert.Error(t, err)
 }
 
@@ -74,7 +74,7 @@ func TestParseListenFromTimeout(t *testing.T) {
 	config, err := decodeConfig([]byte(`{"ListenFrom":[{"Timeout":"3s"}]}`))
 	assert.Nil(t, err)
 	assert.Equal(t, *config.ListenFrom[0].TimeoutDuration, time.Second*3, "Shouldn't fail parsing")
-	config, err = decodeConfig([]byte(`{"ListenFrom":[{"Timeout":"3r"}]}`))
+	_, err = decodeConfig([]byte(`{"ListenFrom":[{"Timeout":"3r"}]}`))
 	assert.Error(t, err)
 }
 
@@ -301,6 +301,7 @@ func TestGatewayConfig_ToEtcdConfig(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			g := &GatewayConfig{
 				ForwardTo:                      tt.fields.ForwardTo,

--- a/config/globbing/glob.go
+++ b/config/globbing/glob.go
@@ -1,8 +1,9 @@
 package globbing
 
 import (
-	"github.com/gobwas/glob"
 	"strings"
+
+	"github.com/gobwas/glob"
 )
 
 // GetGlob takes a config and returns a gobwas Glob that has all other glob/regex operators escaped besides "*".

--- a/config/globbing/glob_test.go
+++ b/config/globbing/glob_test.go
@@ -46,6 +46,7 @@ func TestEscapeMetaCharacters(t *testing.T) {
 	}
 	Convey("should correctly handle special character ", t, func() {
 		for _, c := range cases {
+			c := c
 			Convey(c.desc, func() {
 				g := GetGlob(c.pattern)
 				for _, m := range c.match {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -49,6 +49,7 @@ func TestForwarders(t *testing.T) {
 			{name: "signalfx forwarder with distributor and smart gateway are incompatible", forwardTo: &ForwardTo{Type: "signalfx", TraceDistributor: &sampling.SmartSampleConfig{}, TraceSample: &sampling.SmartSampleConfig{}}, pass: false},
 		}
 		for _, test := range tests {
+			test := test
 			Convey(test.name, func() {
 				f, err := l.Forwarder(test.forwardTo)
 				if test.pass {
@@ -79,6 +80,7 @@ func TestListeners(t *testing.T) {
 			{name: "should load carbon listener", listenFrom: &ListenFrom{Type: "carbon", ListenAddr: pointer.String("127.0.0.1:0")}, pass: true},
 		}
 		for _, test := range tests {
+			test := test
 			Convey(test.name, func() {
 				f, err := l.Listener(nil, test.listenFrom)
 				if test.pass {

--- a/dp/dpbuffered/bufferedforwarder.go
+++ b/dp/dpbuffered/bufferedforwarder.go
@@ -112,7 +112,7 @@ func (e errDPBufferFull) Error() string {
 // AddDatapoints sends the datapoints to a chan buffer that eventually is flushed in big groups
 func (forwarder *BufferedForwarder) AddDatapoints(ctx context.Context, points []*datapoint.Datapoint) error {
 	if forwarder.checker.CtxFlagCheck.HasFlag(ctx) {
-		forwarder.cdim.With(ctx, forwarder.logger).Log("Datapoint call recieved in buffered forwarder")
+		forwarder.cdim.With(ctx, forwarder.logger).Log("Datapoint call received in buffered forwarder")
 	}
 	atomic.AddInt64(&forwarder.stats.totalDatapointsBuffered, int64(len(points)))
 	if *forwarder.config.MaxTotalDatapoints <= atomic.LoadInt64(&forwarder.stats.totalDatapointsBuffered) {

--- a/protocol/carbon/carbon.go
+++ b/protocol/carbon/carbon.go
@@ -51,11 +51,13 @@ func NewCarbonDatapoint(line string, metricDeconstructor metricdeconstructor.Met
 	}
 
 	v, err := func() (datapoint.Value, error) {
-		metricValueInt, err := strconv.ParseInt(parts[1], 10, 64)
+		var metricValueInt int64
+		metricValueInt, err = strconv.ParseInt(parts[1], 10, 64)
 		if err == nil {
 			return datapoint.NewIntValue(metricValueInt), nil
 		}
-		metricValueFloat, err := strconv.ParseFloat(parts[1], 64)
+		var metricValueFloat float64
+		metricValueFloat, err = strconv.ParseFloat(parts[1], 64)
 		if err != nil {
 			return nil, errors.Annotatef(err, "unable to parse carbon metric value on line %s", line)
 		}

--- a/protocol/carbon/carbonforwarder.go
+++ b/protocol/carbon/carbonforwarder.go
@@ -158,7 +158,7 @@ func (f *Forwarder) AddDatapoints(ctx context.Context, points []*datapoint.Datap
 		}
 	}()
 
-	if err := f.setMinTime(ctx, openConnection); err != nil {
+	if err = f.setMinTime(ctx, openConnection); err != nil {
 		return err
 	}
 

--- a/protocol/carbon/carbonlistener.go
+++ b/protocol/carbon/carbonlistener.go
@@ -152,7 +152,8 @@ func (listener *Listener) handleTCPConnection(ctx context.Context, conn carbonLi
 		}
 		line := strings.TrimSpace(string(bytes))
 		if line != "" {
-			dp, err := NewCarbonDatapoint(line, listener.metricDeconstructor)
+			var dp *datapoint.Datapoint
+			dp, err = NewCarbonDatapoint(line, listener.metricDeconstructor)
 			if err != nil {
 				atomic.AddInt64(&listener.stats.invalidDatapoints, 1)
 				connLogger.Log(logkey.CarbonLine, line, log.Err, err, "Received data on a carbon port, but it doesn't look like carbon data")

--- a/protocol/carbon/carbonlistener_test.go
+++ b/protocol/carbon/carbonlistener_test.go
@@ -114,12 +114,14 @@ func TestCarbonForwarderNormal(t *testing.T) {
 				So(tailErr.Timeout(), ShouldBeTrue)
 			}
 			Convey("Should respect ctx cancel", func() {
-				ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Millisecond)
 				eventuallyTimesOut(ctx)
 				cancel()
 			})
 			Convey("Should respect internal timeout", func() {
-				ctx, cancel := context.WithTimeout(ctx, time.Hour*100)
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, time.Hour*100)
 				eventuallyTimesOut(ctx)
 				cancel()
 			})
@@ -147,7 +149,8 @@ func TestCarbonListenerNormalTCP(t *testing.T) {
 
 		Convey("sending invalid datapoint with a valid datapoint still emits valid datapoint", func() {
 			connAddr := fmt.Sprintf("127.0.0.1:%d", nettest.TCPPort(listener))
-			s, err := net.Dial("tcp", connAddr)
+			var s net.Conn
+			s, err = net.Dial("tcp", connAddr)
 			So(err, ShouldBeNil)
 			_, err = io.WriteString(s, "hello world bob\ndice.roll 3 3\n")
 			So(err, ShouldBeNil)
@@ -311,7 +314,8 @@ func TestCarbonListenerNormalUDP(t *testing.T) {
 
 		Convey("sending invalid datapoint with a valid datapoint still emits valid datapoint", func() {
 			connAddr := fmt.Sprintf("127.0.0.1:%d", (uint16)(listener.Addr().(*net.UDPAddr).Port))
-			s, err := net.Dial("udp", connAddr)
+			var s net.Conn
+			s, err = net.Dial("udp", connAddr)
 			So(err, ShouldBeNil)
 			_, err = io.WriteString(s, "hello world bob\ndice.roll 3 3\n")
 			So(err, ShouldBeNil)
@@ -335,7 +339,8 @@ func TestCarbonListenerNormalUDP(t *testing.T) {
 			So(dptest.ExactlyOne(dps, "invalid_datapoints").Value.String(), ShouldEqual, "0")
 
 			connAddr := fmt.Sprintf("127.0.0.1:%d", (uint16)(listener.Addr().(*net.UDPAddr).Port))
-			s, err := net.Dial("udp", connAddr)
+			var s net.Conn
+			s, err = net.Dial("udp", connAddr)
 			So(err, ShouldBeNil)
 			_, err = io.WriteString(s, "hello world bob\n")
 			So(err, ShouldBeNil)
@@ -443,5 +448,6 @@ func TestInvalidConnection(t *testing.T) {
 		So(err, ShouldBeNil)
 		listener, err = NewListener(sendTo, listenFrom)
 		So(err, ShouldNotBeNil)
+		So(listener, ShouldBeNil)
 	})
 }

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor.go
@@ -90,10 +90,7 @@ type idMatcher struct {
 
 // idMatcher matches iff the term is exactly equal to s.Term
 func (s *idMatcher) match(term string) bool {
-	if s.Term == term {
-		return true
-	}
-	return false
+	return s.Term == term
 }
 
 type notMatcher struct {
@@ -102,10 +99,7 @@ type notMatcher struct {
 
 // notMatcher matches iff the term is not exactly equal to s.Term
 func (s *notMatcher) match(term string) bool {
-	if s.Term != term {
-		return true
-	}
-	return false
+	return s.Term != term
 }
 
 type termMatcher struct {
@@ -276,14 +270,14 @@ func (m *configurableDelimiterMetricDeconstructor) verify() error {
 	m.MetricsMap = make(map[int][]*configurableDelimiterMetricRule)
 	for _, t := range m.TypeRules {
 		t.P = m
-		err := t.verify()
+		err = t.verify()
 		if err != nil {
 			return err
 		}
 	}
 	for _, metric := range m.MetricRules {
 		metric.P = m
-		err := metric.verify()
+		err = metric.verify()
 		if err != nil {
 			return err
 		}

--- a/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurabledelimiterdeconstructor_test.go
@@ -53,7 +53,7 @@ var validConfig = `{
 }`
 
 func getData(t *testing.T, data string) map[string]interface{} {
-	dat := make(map[string]interface{}, 0)
+	dat := make(map[string]interface{})
 	err := json.Unmarshal([]byte(data), &dat)
 	assert.NoError(t, err)
 	return dat

--- a/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
+++ b/protocol/carbon/metricdeconstructor/configurableregexdeconstructor_test.go
@@ -33,7 +33,7 @@ var validRegexConfig = `{
 }`
 
 func getRegexData(t *testing.T, data string) map[string]interface{} {
-	dat := make(map[string]interface{}, 0)
+	dat := make(map[string]interface{})
 	err := json.Unmarshal([]byte(data), &dat)
 	assert.NoError(t, err)
 	return dat

--- a/protocol/collectd/collectd.go
+++ b/protocol/collectd/collectd.go
@@ -105,7 +105,7 @@ func GetDimensionsFromName(val *string) (instanceName string, toAddDims map[stri
 				}
 				piece := dimensions[prev:cindex]
 				tindex := strings.Index(piece, "=")
-				if tindex == -1 || strings.Index(piece[tindex+1:], "=") > -1 {
+				if tindex == -1 || strings.Contains(piece[tindex+1:], "=") {
 					return
 				}
 				working[piece[:tindex]] = piece[tindex+1:]
@@ -119,7 +119,7 @@ func GetDimensionsFromName(val *string) (instanceName string, toAddDims map[stri
 			instanceName = left + rest
 		}
 	}
-	return
+	return instanceName, toAddDims
 }
 
 func parseNameForDimensions(dimensions map[string]string, key string, val *string) {
@@ -127,6 +127,7 @@ func parseNameForDimensions(dimensions map[string]string, key string, val *strin
 
 	for k, v := range toAddDims {
 		if _, exists := dimensions[k]; !exists {
+			v := v
 			addIfNotNullOrEmpty(dimensions, k, true, &v)
 		}
 	}
@@ -144,6 +145,7 @@ func pointTypeInstance(point *JSONWriteFormat, dimensions map[string]string, par
 		}
 		for k, v := range toAddDims {
 			if _, exists := dimensions[k]; !exists {
+				v := v
 				addIfNotNullOrEmpty(dimensions, k, true, &v)
 			}
 		}

--- a/protocol/collectd/collectdlistener.go
+++ b/protocol/collectd/collectdlistener.go
@@ -129,7 +129,7 @@ func (decoder *JSONDecoder) Read(ctx context.Context, req *http.Request) error {
 
 func (decoder *JSONDecoder) defaultDims(req *http.Request) map[string]string {
 	params := req.URL.Query()
-	defaultDims := make(map[string]string, 0)
+	defaultDims := make(map[string]string)
 	for key := range params {
 		if strings.HasPrefix(key, sfxDimQueryParamPrefix) {
 			value := params.Get(key)

--- a/protocol/collectd/collectdlistener_test.go
+++ b/protocol/collectd/collectdlistener_test.go
@@ -194,6 +194,7 @@ func TestCollectDListener(t *testing.T) {
 			So(err, ShouldBeNil)
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 			So(atomic.LoadInt64(&callCount), ShouldEqual, 1)
 		})
@@ -206,6 +207,7 @@ func TestCollectDListener(t *testing.T) {
 				req.Header.Set("Content-Type", "application/json")
 				resp, err := client.Do(req)
 				So(err, ShouldBeNil)
+				resp.Body.Close()
 				So(resp.StatusCode, ShouldEqual, http.StatusOK)
 				datapoints = <-sendTo.PointsChan
 				So(len(datapoints), ShouldEqual, 8)
@@ -239,6 +241,7 @@ func TestCollectDListener(t *testing.T) {
 			dps := listener.Datapoints()
 			So(dptest.ExactlyOne(dps, "invalid_collectd_json").Value.String(), ShouldEqual, "0")
 			resp, err := client.Do(req)
+			resp.Body.Close()
 			So(err, ShouldBeNil)
 			So(resp.StatusCode, ShouldEqual, http.StatusBadRequest)
 			dps = listener.Datapoints()

--- a/protocol/filtering/filtering_test.go
+++ b/protocol/filtering/filtering_test.go
@@ -14,6 +14,9 @@ type TestFilteredForwarder struct {
 }
 
 func Test(t *testing.T) {
+	var imNotAMatcher = "im.not.a.matcher"
+	var cpuIdleString = "cpu.idle"
+
 	Convey("bad regexes throw errors", t, func() {
 		filters := FilterObj{
 			Deny: []string{"["},
@@ -37,7 +40,7 @@ func Test(t *testing.T) {
 		So(err, ShouldBeNil)
 		dp := dptest.DP()
 		Convey("cpu.idle is allowed even though cpu.* is denied", func() {
-			dp.Metric = "cpu.idle"
+			dp.Metric = cpuIdleString
 			datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 			So(len(datapoints), ShouldEqual, 1)
 			So(forwarder.FilteredDatapoints, ShouldEqual, 0)
@@ -65,12 +68,12 @@ func Test(t *testing.T) {
 		So(err, ShouldBeNil)
 		dp := dptest.DP()
 		Convey("metrics starting with cpu get accepted", func() {
-			dp.Metric = "cpu.idle"
+			dp.Metric = cpuIdleString
 			datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 			So(len(datapoints), ShouldEqual, 1)
 			So(forwarder.FilteredDatapoints, ShouldEqual, 0)
 			Convey("metrics that don't match allow are denied", func() {
-				dp.Metric = "im.not.a.matcher"
+				dp.Metric = imNotAMatcher
 				datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 				So(len(datapoints), ShouldEqual, 0)
 				So(forwarder.FilteredDatapoints, ShouldEqual, 1)
@@ -86,12 +89,12 @@ func Test(t *testing.T) {
 		So(err, ShouldBeNil)
 		dp := dptest.DP()
 		Convey("metrics starting with cpu get denied", func() {
-			dp.Metric = "cpu.idle"
+			dp.Metric = cpuIdleString
 			datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 			So(len(datapoints), ShouldEqual, 0)
 			So(forwarder.FilteredDatapoints, ShouldEqual, 1)
 			Convey("metrics that don't match cpu are acccepted", func() {
-				dp.Metric = "im.not.a.matcher"
+				dp.Metric = imNotAMatcher
 				datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 				So(len(datapoints), ShouldEqual, 1)
 				So(forwarder.FilteredDatapoints, ShouldEqual, 1)
@@ -106,12 +109,12 @@ func Test(t *testing.T) {
 		So(err, ShouldBeNil)
 		dp := dptest.DP()
 		Convey("metrics starting with cpu get denied", func() {
-			dp.Metric = "cpu.idle"
+			dp.Metric = cpuIdleString
 			datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 			So(len(datapoints), ShouldEqual, 1)
 			So(forwarder.FilteredDatapoints, ShouldEqual, 0)
 			Convey("metrics that don't match cpu are acccepted", func() {
-				dp.Metric = "im.not.a.matcher"
+				dp.Metric = imNotAMatcher
 				datapoints := forwarder.FilterDatapoints([]*datapoint.Datapoint{dp})
 				So(len(datapoints), ShouldEqual, 1)
 				So(forwarder.FilteredDatapoints, ShouldEqual, 0)

--- a/protocol/healthcheck_test.go
+++ b/protocol/healthcheck_test.go
@@ -48,6 +48,7 @@ func grabHealthCheck(t *testing.T, baseURI string, status int) {
 	So(err, ShouldBeNil)
 	resp, err := client.Do(req)
 	So(err, ShouldBeNil)
+	resp.Body.Close()
 	So(resp.StatusCode, ShouldEqual, status)
 }
 

--- a/protocol/prometheus/prometheuslistener_test.go
+++ b/protocol/prometheus/prometheuslistener_test.go
@@ -107,6 +107,7 @@ func TestListener(t *testing.T) {
 			So(err, ShouldBeNil)
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 			So(atomic.LoadInt64(&callCount), ShouldEqual, 1)
 		})
@@ -117,6 +118,7 @@ func TestListener(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 			datapoints := <-sendTo.PointsChan
 			So(len(datapoints), ShouldEqual, 1)
@@ -176,6 +178,7 @@ func TestBad(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 		Convey("Should bork bad readAll", func() {
@@ -187,6 +190,7 @@ func TestBad(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusInternalServerError)
 		})
 		Convey("Should bork on bad data", func() {
@@ -197,6 +201,7 @@ func TestBad(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 		Convey("count bad datapoint", func() {
@@ -207,6 +212,7 @@ func TestBad(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 			for atomic.LoadInt64(&listener.decoder.TotalBadDatapoints) != 1 {
 				runtime.Gosched()
@@ -219,6 +225,7 @@ func TestBad(t *testing.T) {
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusInternalServerError)
 		})
 		Reset(func() {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -1,17 +1,17 @@
 package protocol
 
 import (
-	"testing"
-
+	"context"
 	"net/http"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUneventfulForwarder(t *testing.T) {
 	u := UneventfulForwarder{nil}
-	assert.Equal(t, u.AddEvents(nil, nil), nil)
-	assert.Equal(t, u.AddSpans(nil, nil), nil)
+	assert.Equal(t, u.AddEvents(context.TODO(), nil), nil)
+	assert.Equal(t, u.AddSpans(context.TODO(), nil), nil)
 	assert.Equal(t, int64(0), u.Pipeline())
 	assert.Equal(t, u.StartupFinished(), nil)
 	assert.Equal(t, u.DebugEndpoints(), map[string]http.Handler{})

--- a/protocol/signalfx/format/signalfx_format.go
+++ b/protocol/signalfx/format/signalfx_format.go
@@ -68,7 +68,7 @@ func (a *InputAnnotation) ToV2() *trace.Annotation {
 	}
 }
 
-// GetpointerToInt64 does that
+// GetPointerToInt64 does that
 func GetPointerToInt64(p *float64) *int64 {
 	if p == nil {
 		return nil

--- a/protocol/signalfx/processdebug/processdebug.go
+++ b/protocol/signalfx/processdebug/processdebug.go
@@ -45,7 +45,7 @@ func (p *ProcessDebug) AddSpans(ctx context.Context, spans []*trace.Span) error 
 			s.Tags[spTagName] = "1"
 			continue
 		}
-		if s.Tags != nil && "1" == s.Tags[spTagName] {
+		if s.Tags != nil && s.Tags[spTagName] == "1" {
 			s.Debug = pointer.Bool(true)
 		}
 	}

--- a/protocol/signalfx/signalfxforwarder.go
+++ b/protocol/signalfx/signalfxforwarder.go
@@ -172,7 +172,7 @@ func (connector *Forwarder) AddDatapoints(ctx context.Context, datapoints []*dat
 	start := time.Now()
 	atomic.AddInt64(&connector.stats.pipeline, int64(len(datapoints)))
 	defer atomic.AddInt64(&connector.stats.pipeline, -int64(len(datapoints)))
-	defer connector.stats.requests.Add(float64(time.Now().Sub(start).Nanoseconds()))
+	defer connector.stats.requests.Add(float64(time.Since(start).Nanoseconds()))
 	defer connector.stats.drainSize.Add(float64(len(datapoints)))
 	atomic.AddInt64(&connector.stats.totalDatapointsForwarded, int64(len(datapoints)))
 	datapoints = connector.emptyMetricNameFilter.FilterDatapoints(datapoints)

--- a/protocol/signalfx/signalfxlistener_test.go
+++ b/protocol/signalfx/signalfxlistener_test.go
@@ -147,10 +147,11 @@ func verifyEventRequest(baseURI string, contentType string, path string, body io
 				}
 				resp, err := client.Do(req)
 				So(err, ShouldBeNil)
+				resp.Body.Close()
 				So(resp.StatusCode, ShouldEqual, http.StatusOK)
 				Convey("and the generated event should be what we expect", func() {
 					runtime.Gosched()
-					_ = <-doneSignal
+					<-doneSignal
 					So(eventType, ShouldEqual, eOut.EventType)
 					So(category, ShouldEqual, eOut.Category)
 					if dimensions != nil {
@@ -293,6 +294,7 @@ func TestSignalfxListener(t *testing.T) {
 			So(err, ShouldBeNil)
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 		})
 		Convey("And a signalfx forwarder with a smart sampler config should not work", func() {
@@ -408,6 +410,7 @@ func TestSignalfxListener(t *testing.T) {
 			req.Header.Add("Content-Type", contentType)
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 		}
 		verifyStatusCode := func(body string, contentType string, pathSuffix string, expectedStatusCode int) {
@@ -417,6 +420,7 @@ func TestSignalfxListener(t *testing.T) {
 			req.Header.Add("Content-Type", contentType)
 			resp, err := client.Do(req)
 			So(err, ShouldBeNil)
+			resp.Body.Close()
 			So(resp.StatusCode, ShouldEqual, expectedStatusCode)
 		}
 		Convey("given a json body without a timestamp or category", func() {
@@ -568,6 +572,7 @@ func TestSignalfxListener(t *testing.T) {
 				req.Header.Add("Content-Type", contentType)
 				resp, err := client.Do(req)
 				So(err, ShouldBeNil)
+				resp.Body.Close()
 				So(resp.StatusCode, ShouldEqual, expectedStatusCode)
 			}
 			for _, v := range []struct {
@@ -582,6 +587,7 @@ func TestSignalfxListener(t *testing.T) {
 				{"just an object", "{}", "application/json", "/v1/trace", 400},
 				{"not thrift", "{}", "application/x-thrift", "/v1/trace", 400},
 			} {
+				v := v
 				Convey(v.desc, func() {
 					verifyStatusCode(v.body, v.content, v.path, v.expected)
 				})

--- a/protocol/signalfx/spanobfuscation/tagmatchrule.go
+++ b/protocol/signalfx/spanobfuscation/tagmatchrule.go
@@ -24,7 +24,7 @@ type TagMatchRuleConfig struct {
 }
 
 func getRules(ruleConfigs []*TagMatchRuleConfig) ([]*rule, error) {
-	var rules []*rule
+	var rules = make([]*rule, 0, len(ruleConfigs))
 	for _, r := range ruleConfigs {
 		service := "*"
 		if r.Service != nil {

--- a/protocol/signalfx/spanobfuscation/tagmatchrule_test.go
+++ b/protocol/signalfx/spanobfuscation/tagmatchrule_test.go
@@ -62,6 +62,7 @@ func TestGetRules(t *testing.T) {
 	}
 	Convey("we should create a valid SpanTagRemoval with", t, func() {
 		for _, tc := range cases {
+			tc := tc
 			Convey(tc.desc, func() {
 				r, err := getRules(tc.config)
 				So(err, ShouldBeNil)

--- a/protocol/signalfx/tagreplace/tagreplace.go
+++ b/protocol/signalfx/tagreplace/tagreplace.go
@@ -76,7 +76,7 @@ func (t *TagReplace) AddSpans(ctx context.Context, spans []*trace.Span) error {
 
 // New returns you a new TagReplace object
 func New(ruleStrings []string, exitEarly bool, next sink) (*TagReplace, error) {
-	var rules []*regexp.Regexp
+	var rules = make([]*regexp.Regexp, 0, len(ruleStrings))
 	for _, r := range ruleStrings {
 		var err error
 		var rp *regexp.Regexp

--- a/protocol/signalfx/tagreplace/tagreplace_test.go
+++ b/protocol/signalfx/tagreplace/tagreplace_test.go
@@ -59,6 +59,7 @@ func Test(t *testing.T) {
 	}
 	Convey("test tag replace", t, func() {
 		for _, tc := range cases {
+			tc := tc
 			Convey("Testing case: "+tc.desc, func() {
 				e := &end{}
 				tr, err := New(tc.rules, tc.exitEarly, e)

--- a/protocol/signalfx/trace_jaeger.go
+++ b/protocol/signalfx/trace_jaeger.go
@@ -82,7 +82,7 @@ func NewJaegerThriftDecoderBase() *JaegerThriftDecoderBase {
 	}
 }
 
-// JeagerThriftToSAPMDecoder reads an jaeger thrift http.Request and parses it's body into a splunksapm.PostSpansRequest
+// JaegerThriftToSAPMDecoder reads an jaeger thrift http.Request and parses it's body into a splunksapm.PostSpansRequest
 type JaegerThriftToSAPMDecoder struct {
 	*JaegerThriftDecoderBase
 }

--- a/protocol/signalfx/trace_jaeger.go
+++ b/protocol/signalfx/trace_jaeger.go
@@ -62,12 +62,12 @@ func (j *JaegerThriftDecoderBase) Read(ctx context.Context, req *http.Request) (
 		Buffer: buf,
 	})
 
-	batch := jThrift.Batch{}
+	batch := &jThrift.Batch{}
 	if err := batch.Read(protocol); err != nil {
 		return nil, ErrInvalidJaegerTraceFormat
 	}
 
-	return &batch, nil
+	return batch, nil
 }
 
 // NewJaegerThriftDecoderBase returns a new JaegerThriftDecoderBase

--- a/protocol/signalfx/trace_zipkin_test.go
+++ b/protocol/signalfx/trace_zipkin_test.go
@@ -276,6 +276,7 @@ func TestZipkinTraceDecoder(t *testing.T) {
 
 // Tests converted from
 // https://github.com/openzipkin/zipkin/blob/2.8.4/zipkin/src/test/java/zipkin/internal/V2SpanConverterTest.java
+// nolint:funlen
 func TestZipkinTraceConversion(t *testing.T) {
 	frontend := &trace.Endpoint{
 		ServiceName: pointer.String("frontend"),
@@ -1438,6 +1439,7 @@ func TestZipkinTraceConversion(t *testing.T) {
 	})
 }
 
+// nolint:funlen
 func TestParseSAPMFromRequest(t *testing.T) {
 	Convey("SignalFx / Zipkin v2 spans get converted to jaeger batches", t, func() {
 		// the following test data comes from the github.com/signalfx/golib/trace/translator tests
@@ -1991,7 +1993,7 @@ func TestParseSAPMFromRequest(t *testing.T) {
 		}
 
 		span := []*InputSpan{
-			&InputSpan{
+			{
 				Span: trace.Span{
 					TraceID: "1",
 					Name:    pointer.String("test"),
@@ -2010,48 +2012,48 @@ func TestParseSAPMFromRequest(t *testing.T) {
 		}
 
 		want := []*jaegerpb.Batch{
-			&jaegerpb.Batch{
+			{
 				Process: jaegerpb.NewProcess("frontend", []jaegerpb.KeyValue{
-					jaegerpb.KeyValue{
+					{
 						Key:   "ip",
 						VStr:  "127.0.0.1",
 						VType: jaegerpb.ValueType_STRING,
 					},
 				}),
 				Spans: []*jaegerpb.Span{
-					&jaegerpb.Span{
+					{
 						TraceID:       jaegerpb.NewTraceID(0x0, 0x1),
 						SpanID:        jaegerpb.NewSpanID(2),
 						OperationName: "test",
 						Logs:          []jaegerpb.Log{},
 						Tags: []jaegerpb.KeyValue{
-							jaegerpb.KeyValue{
+							{
 								Key:   "bool",
 								VStr:  "true",
 								VType: jaegerpb.ValueType_STRING,
 							},
-							jaegerpb.KeyValue{
+							{
 								Key: "bytes",
 								// byte arrays are json marshalled into base64
 								VStr:  base64.StdEncoding.EncodeToString([]byte("hello")),
 								VType: jaegerpb.ValueType_STRING,
 							},
-							jaegerpb.KeyValue{
+							{
 								Key:   "short",
 								VStr:  "20",
 								VType: jaegerpb.ValueType_STRING,
 							},
-							jaegerpb.KeyValue{
+							{
 								Key:   "int",
 								VStr:  "32800",
 								VType: jaegerpb.ValueType_STRING,
 							},
-							jaegerpb.KeyValue{
+							{
 								Key:   "long",
 								VStr:  "2147483700",
 								VType: jaegerpb.ValueType_STRING,
 							},
-							jaegerpb.KeyValue{
+							{
 								Key:   "double",
 								VStr:  "3.1415",
 								VType: jaegerpb.ValueType_STRING,
@@ -2147,9 +2149,8 @@ func sortLogs(t []jaegerpb.Log) {
 	sort.Slice(t, func(i, j int) bool {
 		return t[i].String() <= t[j].String()
 	})
-	// noscopelint
-	for _, l := range t {
-		sortTags(l.Fields)
+	for i := 0; i < len(t); i++ {
+		sortTags(t[i].Fields)
 	}
 }
 

--- a/protocol/signalfx/unified_test.go
+++ b/protocol/signalfx/unified_test.go
@@ -72,8 +72,8 @@ func TestFromChain(t *testing.T) {
 	e0 := expect{count: 0}
 
 	chain := FromChain(&e2, e0.next, e1.next)
-	log.IfErr(log.Panic, chain.AddDatapoints(nil, []*datapoint.Datapoint{}))
-	log.IfErr(log.Panic, chain.AddEvents(nil, []*event.Event{}))
+	log.IfErr(log.Panic, chain.AddDatapoints(context.TODO(), []*datapoint.Datapoint{}))
+	log.IfErr(log.Panic, chain.AddEvents(context.TODO(), []*event.Event{}))
 }
 
 func TestIncludingDimensions(t *testing.T) {

--- a/protocol/wavefront/wavefrontlistener.go
+++ b/protocol/wavefront/wavefrontlistener.go
@@ -119,7 +119,7 @@ func extractCollectdDimensions(doit bool, metricName string) (string, map[string
 	}
 }
 
-// i always wonder about passing strings around and if it's worth it to use thier address
+// i always wonder about passing strings around and if it's worth it to use their address
 // TODO write a benchmark to test performance and garbage generation here
 func stripQuotes(s string) string {
 	if s[0] == '"' {

--- a/protocol/wavefront/wavefrontlistener_test.go
+++ b/protocol/wavefront/wavefrontlistener_test.go
@@ -70,6 +70,7 @@ func TestFromWavefrontDatapoint(t *testing.T) {
 			expectedValue:      "566.005707",
 		},
 	} {
+		tt := tt
 		Convey(tt.desc, t, func() {
 			listener := &Listener{}
 			listener.extractCollectdDimensions = tt.doit

--- a/protocol/zipper/zipper.go
+++ b/protocol/zipper/zipper.go
@@ -27,7 +27,7 @@ type ReadZipper struct {
 func (z *ReadZipper) GzipHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var err error
-		if "gzip" == r.Header.Get("Content-Encoding") {
+		if r.Header.Get("Content-Encoding") == "gzip" {
 			gzi := z.zippers.Get()
 			if gzi != nil {
 				gz := gzi.(*gzip.Reader)
@@ -47,7 +47,7 @@ func (z *ReadZipper) GzipHandler(h http.Handler) http.Handler {
 		if err != nil {
 			atomic.AddInt64(&z.ErrCount, 1)
 			w.WriteHeader(http.StatusBadRequest)
-			_, err := w.Write([]byte("error handling gzip compressed request " + err.Error()))
+			_, err = w.Write([]byte("error handling gzip compressed request " + err.Error()))
 			log.IfErr(z.Log, err)
 			return
 		}

--- a/protocol/zipper/zipper_test.go
+++ b/protocol/zipper/zipper_test.go
@@ -20,13 +20,12 @@ func (f *foo) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(req.Body)
 	if err == nil {
-		if "OK" == string(buf.Bytes()) {
+		if buf.String() == "OK" {
 			rw.WriteHeader(http.StatusOK)
 		}
 	}
 	fmt.Println(err)
 	rw.WriteHeader(http.StatusBadRequest)
-	return
 }
 
 func Test(t *testing.T) {
@@ -54,6 +53,7 @@ func Test(t *testing.T) {
 			{badZippers, "test gzipped failure", zipped.Bytes(), http.StatusBadRequest, map[string]string{"Content-Encoding": "gzip"}},
 		}
 		for _, test := range tests {
+			test := test
 			Convey(test.name, func() {
 				req, err := http.NewRequest("GET", "/health-check", bytes.NewBuffer(test.data))
 				for k, v := range test.headers {


### PR DESCRIPTION
* refactor core jaeger thrift request decoder
* git ignore golang coverage output
* add jaeger thrift to sapm http request decoder