### PR TITLE
Add pom.xml to generate a JAR file from logs protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.signalfx.public</groupId>
+    <artifactId>ingest-protocols</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+      <dependency>
+            <groupId>com.github.os72</groupId>
+            <artifactId>protobuf-java-shaded-360</artifactId>
+            <version>0.9</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Maven Central</name>
+            <layout>default</layout>
+            <url>https://repo1.maven.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.os72</groupId>
+                <artifactId>protoc-jar-maven-plugin</artifactId>
+                <version>3.11.4</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <protocVersion>3.5.1</protocVersion>
+                            <type>java-shaded</type>
+                            <inputDirectories>
+                                <include>
+                                    protocol/signalfx/format/log
+                                </include>
+                            </inputDirectories>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+
+        </plugins>
+
+        <resources>
+            <!--Include logs proto file in jar-->
+            <resource>
+                <directory>${basedir}/protocol/signalfx/format/log</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>signalfx_log.proto</include>
+                </includes>
+            </resource>
+
+        </resources>
+
+    </build>
+
+</project>


### PR DESCRIPTION
Java projects needing to consume logs in signalfx_logs protobuf format currently have to compile signalfx_logs.proto during their own build. This means an unnecessary dependency on the `protoc`. Proposed pom.xml will produce a client jar for the protobuf. When built by CI and published to the maven repo, clients will only depend on the client jar and thus can skip `protoc` compilation step.

I'm not entirely sure what are the best values for groupId/artifactId. Current values are based on other public signalfx jars. Version handling is not entirely clear as well. Ideally it should be paired with protobuf-s own version if there would be one.