### PR TITLE
Replace shadowed protobuf with the original one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@
 
 # IDEs
 .idea/
+*.iml
 
 # Test coverage output
 coverage.out.all
+
+# Maven build dir
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,16 @@
 
     <groupId>com.signalfx.public</groupId>
     <artifactId>ingest-protocols</artifactId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
+    <properties>
+        <revision>1.0.0</revision>
+    </properties>
 
     <dependencies>
-      <dependency>
-            <groupId>com.github.os72</groupId>
-            <artifactId>protobuf-java-shaded-360</artifactId>
-            <version>0.9</version>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.12.4</version>
         </dependency>
     </dependencies>
 
@@ -44,36 +47,28 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
-
-            <plugin>
-                <groupId>com.github.os72</groupId>
-                <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.4</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <protocVersion>3.5.1</protocVersion>
-                            <type>java-shaded</type>
-                            <inputDirectories>
-                                <include>
-                                    protocol/signalfx/format/log
-                                </include>
-                            </inputDirectories>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
                 <configuration>
                     <skip>false</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+                <configuration>
+                    <protoSourceRoot>protocol/signalfx/format/log</protoSourceRoot>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>


### PR DESCRIPTION
This will allow to make use of newer versions installed in the build environment. Also revision is now a property which can be given externally, e.g. by the build runner.