### PR TITLE
protocol/otlp: Handle stringification of attributes of type bytes

### DIFF
--- a/protocol/otlp/metrics.go
+++ b/protocol/otlp/metrics.go
@@ -18,6 +18,7 @@
 package otlp
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"math"
 	"strconv"
@@ -327,6 +328,9 @@ func StringifyAnyValue(a *commonv1.AnyValue) string {
 	case *commonv1.AnyValue_StringValue:
 		v = a.GetStringValue()
 
+	case *commonv1.AnyValue_BytesValue:
+		v = base64.StdEncoding.EncodeToString(a.GetBytesValue())
+
 	case *commonv1.AnyValue_BoolValue:
 		v = strconv.FormatBool(a.GetBoolValue())
 
@@ -352,6 +356,9 @@ func anyValueToRaw(a *commonv1.AnyValue) interface{} {
 	switch a.GetValue().(type) {
 	case *commonv1.AnyValue_StringValue:
 		v = a.GetStringValue()
+
+	case *commonv1.AnyValue_BytesValue:
+		v = a.GetBytesValue()
 
 	case *commonv1.AnyValue_BoolValue:
 		v = a.GetBoolValue()

--- a/protocol/otlp/metrics_test.go
+++ b/protocol/otlp/metrics_test.go
@@ -657,6 +657,7 @@ func TestAttributesToDimensions(t *testing.T) {
 						{Key: "k3", Value: nil},
 						{Key: "k4", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_DoubleValue{DoubleValue: 40.3}}},
 						{Key: "k5", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_IntValue{IntValue: 41}}},
+						{Key: "k6", Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_BytesValue{BytesValue: []byte("n2")}}},
 					}}}},
 			},
 			{
@@ -671,6 +672,10 @@ func TestAttributesToDimensions(t *testing.T) {
 				Key:   "j",
 				Value: &commonv1.AnyValue{Value: nil},
 			},
+			{
+				Key: "k",
+				Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_BytesValue{BytesValue: []byte("to boldly go")}},
+			},
 		}
 
 		dimKVs := stringifyAttributes(attrs)
@@ -682,8 +687,10 @@ func TestAttributesToDimensions(t *testing.T) {
 			"d": "44",
 			"e": "45.1",
 			"f": `["n1","n2"]`,
-			"g": `{"k1":"n1","k2":false,"k3":null,"k4":40.3,"k5":41}`,
+			"g": `{"k1":"n1","k2":false,"k3":null,"k4":40.3,"k5":41,"k6":"bjI="}`,
 			"i": "0",
+			// No entry for "j" because it's nil and would be skipped by ToDatapoint()
+			"k": "dG8gYm9sZGx5IGdv",
 		})
 	})
 


### PR DESCRIPTION
This change handles common.AnyValue type of AnyValue_BytesValue in incoming attributes so they can be correctly converted into dimensions.