### PR TITLE
Use ScopeMetrics in OTLP code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/smartystreets/assertions v1.0.1
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.7.0
-	go.opentelemetry.io/proto/otlp v0.12.0
+	go.opentelemetry.io/proto/otlp v0.16.0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
 )
@@ -33,6 +33,7 @@ require (
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -40,6 +41,6 @@ require (
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/text v0.3.6 // indirect
-	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -430,6 +430,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -556,6 +558,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.14.5/go.mod h1:UJ0EZAp832vCd54Wev9N1BMKEyvcZ5+IM0AwDrnlkEc=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
@@ -1125,8 +1129,8 @@ go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.opentelemetry.io/collector v0.28.0/go.mod h1:AP/BTXwo1eedoJO7V+HQ68CSvJU1lcdqOzJCgt1VsNs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go.opentelemetry.io/proto/otlp v0.12.0 h1:CMJ/3Wp7iOWES+CYLfnBv+DVmPbB+kmy9PJ92XvlR6c=
-go.opentelemetry.io/proto/otlp v0.12.0/go.mod h1:TsIjwGWIx5VFYv9KGVlOpxoBl5Dy+63SUguV7GGvlSQ=
+go.opentelemetry.io/proto/otlp v0.16.0 h1:WHzDWdXUvbc5bG2ObdrGfaNpQz7ft7QN9HHmJlbiB1E=
+go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -1288,6 +1292,7 @@ golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1601,8 +1606,9 @@ google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210312152112-fc591d9ea70f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
-google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c h1:wtujag7C+4D6KMoulW9YauvK2lgdvCMS260jsqqBXr0=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1 h1:b9mVrqYfq3P4bCdaLg1qtBnPzUYgglsIdjZkL/fQVOE=
+google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1631,6 +1637,7 @@ google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAG
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/protocol/otlp/decoder_test.go
+++ b/protocol/otlp/decoder_test.go
@@ -53,7 +53,7 @@ func TestDecoder(t *testing.T) {
 			var msg metricsservicev1.ExportMetricsServiceRequest
 			msg.ResourceMetrics = []*metricsv1.ResourceMetrics{
 				{
-					InstrumentationLibraryMetrics: []*metricsv1.InstrumentationLibraryMetrics{
+					ScopeMetrics: []*metricsv1.ScopeMetrics{
 						{
 							Metrics: []*metricsv1.Metric{
 								{

--- a/protocol/otlp/metrics.go
+++ b/protocol/otlp/metrics.go
@@ -114,6 +114,11 @@ func SignalFxMetricsFromOTLPResourceMetrics(rms []*metricsv1.ResourceMetrics) []
 	var sfxDps []SignalFxMetric
 
 	for _, rm := range rms {
+		for _, ilm := range rm.GetScopeMetrics() {
+			for _, m := range ilm.GetMetrics() {
+				sfxDps = append(sfxDps, SignalFxMetricsFromOTLPMetric(m)...)
+			}
+		}
 		for _, ilm := range rm.GetInstrumentationLibraryMetrics() {
 			for _, m := range ilm.GetMetrics() {
 				sfxDps = append(sfxDps, SignalFxMetricsFromOTLPMetric(m)...)

--- a/protocol/otlp/metrics_test.go
+++ b/protocol/otlp/metrics_test.go
@@ -15,6 +15,7 @@
 package otlp
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -82,7 +83,7 @@ func Test_FromMetrics(t *testing.T) {
 		return &metricsv1.HistogramDataPoint{
 			TimeUnixNano:   uint64(ts.UnixNano()),
 			Count:          16,
-			Sum:            100.0,
+			Sum:            float64Pointer(100.0),
 			ExplicitBounds: histBounds,
 			BucketCounts:   histCounts,
 			Attributes:     stringMapToAttributeMap(labelMap),
@@ -94,7 +95,7 @@ func Test_FromMetrics(t *testing.T) {
 		return &metricsv1.HistogramDataPoint{
 			TimeUnixNano:   uint64(ts.UnixNano()),
 			Count:          16,
-			Sum:            100.0,
+			Sum:            float64Pointer(100.0),
 			ExplicitBounds: histBounds,
 			BucketCounts:   []uint64{4},
 			Attributes:     stringMapToAttributeMap(labelMap),
@@ -105,7 +106,7 @@ func Test_FromMetrics(t *testing.T) {
 		return &metricsv1.HistogramDataPoint{
 			TimeUnixNano:   uint64(ts.UnixNano()),
 			Count:          16,
-			Sum:            100,
+			Sum:            float64Pointer(100),
 			ExplicitBounds: histBounds,
 			BucketCounts:   histCounts,
 			Attributes:     stringMapToAttributeMap(labelMap),
@@ -117,7 +118,7 @@ func Test_FromMetrics(t *testing.T) {
 		return &metricsv1.HistogramDataPoint{
 			TimeUnixNano:   uint64(ts.UnixNano()),
 			Count:          16,
-			Sum:            100,
+			Sum:            float64Pointer(100),
 			ExplicitBounds: histBounds,
 			BucketCounts:   []uint64{4},
 			Attributes:     stringMapToAttributeMap(labelMap),
@@ -127,7 +128,7 @@ func Test_FromMetrics(t *testing.T) {
 	makeHistDPNoBuckets := func() *metricsv1.HistogramDataPoint {
 		return &metricsv1.HistogramDataPoint{
 			Count:        2,
-			Sum:          10,
+			Sum:          float64Pointer(10),
 			TimeUnixNano: uint64(ts.UnixNano()),
 			Attributes:   stringMapToAttributeMap(labelMap),
 		}
@@ -162,214 +163,226 @@ func Test_FromMetrics(t *testing.T) {
 		}
 	}
 
-	tests := []struct {
-		name              string
-		metricsFn         func() []*metricsv1.ResourceMetrics
-		wantSfxDataPoints []*datapoint.Datapoint
-	}{
-		{
-			name: "nil_node_nil_resources_no_dims",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
+	for _, useScopeMetrics := range []bool{false, true} {
+		createRMS := func() (*metricsv1.ResourceMetrics, *[]*metricsv1.Metric) {
+			out := &metricsv1.ResourceMetrics{}
+			var metrics *[]*metricsv1.Metric
+			if useScopeMetrics {
+				ilm := &metricsv1.ScopeMetrics{}
+				out.ScopeMetrics = append(out.ScopeMetrics, ilm)
+				metrics = &ilm.Metrics
+			} else {
 				ilm := &metricsv1.InstrumentationLibraryMetrics{}
 				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
+				metrics = &ilm.Metrics
+			}
 
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "gauge_double_with_no_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "gauge_int_with_no_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64Pt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "cumulative_double_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "cumulative_int_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64Pt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "delta_double_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "delta_int_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64Pt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "gauge_sum_double_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic: false,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "gauge_sum_int_with_no_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic: false,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64Pt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "gauge_sum_int_with_nil_value",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic: false,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeNilValuePt(),
-								},
-							},
-						},
-					},
-					{
-						Name: "nil_data",
-						Data: nil,
-					},
-				}
+			return out, metrics
+		}
+		tests := []struct {
+			name              string
+			metricsFn         func() []*metricsv1.ResourceMetrics
+			wantSfxDataPoints []*datapoint.Datapoint
+		}{
+			{
+				name: "nil_node_nil_resources_no_dims",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
 
-				return []*metricsv1.ResourceMetrics{out}
-			},
-			wantSfxDataPoints: []*datapoint.Datapoint{
-				doubleSFxDataPoint("gauge_double_with_no_dims", datapoint.Gauge, nil, doubleVal),
-				int64SFxDataPoint("gauge_int_with_no_dims", datapoint.Gauge, nil, int64Val),
-				doubleSFxDataPoint("cumulative_double_with_no_dims", datapoint.Counter, nil, doubleVal),
-				int64SFxDataPoint("cumulative_int_with_no_dims", datapoint.Counter, nil, int64Val),
-				doubleSFxDataPoint("delta_double_with_no_dims", datapoint.Count, nil, doubleVal),
-				int64SFxDataPoint("delta_int_with_no_dims", datapoint.Count, nil, int64Val),
-				doubleSFxDataPoint("gauge_sum_double_with_no_dims", datapoint.Gauge, nil, doubleVal),
-				int64SFxDataPoint("gauge_sum_int_with_no_dims", datapoint.Gauge, nil, int64Val),
-				{
-					Metric:     "gauge_sum_int_with_nil_value",
-					Timestamp:  ts,
-					Value:      nil,
-					MetricType: datapoint.Gauge,
-					Dimensions: map[string]string{},
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "gauge_double_with_no_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "gauge_int_with_no_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64Pt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "cumulative_double_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "cumulative_int_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64Pt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "delta_double_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "delta_int_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64Pt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "gauge_sum_double_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic: false,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "gauge_sum_int_with_no_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic: false,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64Pt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "gauge_sum_int_with_nil_value",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic: false,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeNilValuePt(),
+									},
+								},
+							},
+						},
+						{
+							Name: "nil_data",
+							Data: nil,
+						},
+					}
+
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: []*datapoint.Datapoint{
+					doubleSFxDataPoint("gauge_double_with_no_dims", datapoint.Gauge, nil, doubleVal),
+					int64SFxDataPoint("gauge_int_with_no_dims", datapoint.Gauge, nil, int64Val),
+					doubleSFxDataPoint("cumulative_double_with_no_dims", datapoint.Counter, nil, doubleVal),
+					int64SFxDataPoint("cumulative_int_with_no_dims", datapoint.Counter, nil, int64Val),
+					doubleSFxDataPoint("delta_double_with_no_dims", datapoint.Count, nil, doubleVal),
+					int64SFxDataPoint("delta_int_with_no_dims", datapoint.Count, nil, int64Val),
+					doubleSFxDataPoint("gauge_sum_double_with_no_dims", datapoint.Gauge, nil, doubleVal),
+					int64SFxDataPoint("gauge_sum_int_with_no_dims", datapoint.Gauge, nil, int64Val),
+					{
+						Metric:     "gauge_sum_int_with_nil_value",
+						Timestamp:  ts,
+						Value:      nil,
+						MetricType: datapoint.Gauge,
+						Dimensions: map[string]string{},
+					},
 				},
 			},
-		},
-		{
-			name: "nil_node_and_resources_with_dims",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
+			{
+				name: "nil_node_and_resources_with_dims",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
 
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "gauge_double_with_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePtWithLabels(),
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "gauge_double_with_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-					{
-						Name: "gauge_int_with_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64PtWithLabels(),
+						{
+							Name: "gauge_int_with_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64PtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-					{
-						Name: "cumulative_double_with_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePtWithLabels(),
+						{
+							Name: "cumulative_double_with_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-					{
-						Name: "cumulative_int_with_dims",
-						Data: &metricsv1.Metric_Sum{
-							Sum: &metricsv1.Sum{
-								IsMonotonic:            true,
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64PtWithLabels(),
+						{
+							Name: "cumulative_int_with_dims",
+							Data: &metricsv1.Metric_Sum{
+								Sum: &metricsv1.Sum{
+									IsMonotonic:            true,
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_CUMULATIVE,
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64PtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-				}
+					}
 
-				return []*metricsv1.ResourceMetrics{out}
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: []*datapoint.Datapoint{
+					doubleSFxDataPoint("gauge_double_with_dims", datapoint.Gauge, labelMap, doubleVal),
+					int64SFxDataPoint("gauge_int_with_dims", datapoint.Gauge, labelMap, int64Val),
+					doubleSFxDataPoint("cumulative_double_with_dims", datapoint.Counter, labelMap, doubleVal),
+					int64SFxDataPoint("cumulative_int_with_dims", datapoint.Counter, labelMap, int64Val),
+				},
 			},
-			wantSfxDataPoints: []*datapoint.Datapoint{
-				doubleSFxDataPoint("gauge_double_with_dims", datapoint.Gauge, labelMap, doubleVal),
-				int64SFxDataPoint("gauge_int_with_dims", datapoint.Gauge, labelMap, int64Val),
-				doubleSFxDataPoint("cumulative_double_with_dims", datapoint.Counter, labelMap, doubleVal),
-				int64SFxDataPoint("cumulative_int_with_dims", datapoint.Counter, labelMap, int64Val),
-			},
-		},
-		{
-			name: "with_node_resources_dims",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{
-					Resource: &resourcev1.Resource{
+			{
+				name: "with_node_resources_dims",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
+					out.Resource = &resourcev1.Resource{
 						Attributes: []*commonv1.KeyValue{
 							{
 								Key:   "k_r0",
@@ -388,225 +401,221 @@ func Test_FromMetrics(t *testing.T) {
 								Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: "v_n1"}},
 							},
 						},
-					},
-				}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
+					}
 
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "gauge_double_with_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeDoublePtWithLabels(),
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "gauge_double_with_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeDoublePtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-					{
-						Name: "gauge_int_with_dims",
-						Data: &metricsv1.Metric_Gauge{
-							Gauge: &metricsv1.Gauge{
-								DataPoints: []*metricsv1.NumberDataPoint{
-									makeInt64PtWithLabels(),
+						{
+							Name: "gauge_int_with_dims",
+							Data: &metricsv1.Metric_Gauge{
+								Gauge: &metricsv1.Gauge{
+									DataPoints: []*metricsv1.NumberDataPoint{
+										makeInt64PtWithLabels(),
+									},
 								},
 							},
 						},
-					},
-				}
-				return []*metricsv1.ResourceMetrics{out}
-			},
-			wantSfxDataPoints: []*datapoint.Datapoint{
-				doubleSFxDataPoint(
-					"gauge_double_with_dims",
-					datapoint.Gauge,
-					mergeStringMaps(map[string]string{
-						"k_n0": "v_n0",
-						"k_n1": "v_n1",
-						"k_r0": "v_r0",
-						"k_r1": "v_r1",
-					}, labelMap),
-					doubleVal),
-				int64SFxDataPoint(
-					"gauge_int_with_dims",
-					datapoint.Gauge,
-					mergeStringMaps(map[string]string{
-						"k_n0": "v_n0",
-						"k_n1": "v_n1",
-						"k_r0": "v_r0",
-						"k_r1": "v_r1",
-					}, labelMap),
-					int64Val),
-			},
-		},
-		{
-			name: "histograms",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
-
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "int_histo",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeIntHistDP(),
-								},
-							},
-						},
-					},
-					{
-						Name: "int_delta_histo",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeIntHistDP(),
-								},
-							},
-						},
-					},
-					{
-						Name: "double_histo",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeDoubleHistDP(),
-								},
-							},
-						},
-					},
-					{
-						Name: "double_delta_histo",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeDoubleHistDP(),
-								},
-							},
-						},
-					},
-					{
-						Name: "double_histo_bad_counts",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeDoubleHistDPBadCounts(),
-								},
-							},
-						},
-					},
-					{
-						Name: "int_histo_bad_counts",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeIntHistDPBadCounts(),
-								},
-							},
-						},
-					},
-				}
-				return []*metricsv1.ResourceMetrics{out}
-			},
-			wantSfxDataPoints: mergeDPs(
-				expectedFromHistogram("int_histo", labelMap, intHistDP, false),
-				expectedFromHistogram("int_delta_histo", labelMap, intHistDP, true),
-				expectedFromHistogram("double_histo", labelMap, doubleHistDP, false),
-				expectedFromHistogram("double_delta_histo", labelMap, doubleHistDP, true),
-				[]*datapoint.Datapoint{
-					int64SFxDataPoint("double_histo_bad_counts_count", datapoint.Counter, labelMap, int64(doubleHistDP.Count)),
-					doubleSFxDataPoint("double_histo_bad_counts", datapoint.Counter, labelMap, doubleHistDP.Sum),
+					}
+					return []*metricsv1.ResourceMetrics{out}
 				},
-				[]*datapoint.Datapoint{
-					int64SFxDataPoint("int_histo_bad_counts_count", datapoint.Counter, labelMap, int64(intHistDP.Count)),
-					doubleSFxDataPoint("int_histo_bad_counts", datapoint.Counter, labelMap, intHistDP.Sum),
+				wantSfxDataPoints: []*datapoint.Datapoint{
+					doubleSFxDataPoint(
+						"gauge_double_with_dims",
+						datapoint.Gauge,
+						mergeStringMaps(map[string]string{
+							"k_n0": "v_n0",
+							"k_n1": "v_n1",
+							"k_r0": "v_r0",
+							"k_r1": "v_r1",
+						}, labelMap),
+						doubleVal),
+					int64SFxDataPoint(
+						"gauge_int_with_dims",
+						datapoint.Gauge,
+						mergeStringMaps(map[string]string{
+							"k_n0": "v_n0",
+							"k_n1": "v_n1",
+							"k_r0": "v_r0",
+							"k_r1": "v_r1",
+						}, labelMap),
+						int64Val),
 				},
-			),
-		},
-		{
-			name: "distribution_no_buckets",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
+			},
+			{
+				name: "histograms",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
 
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "no_bucket_histo",
-						Data: &metricsv1.Metric_Histogram{
-							Histogram: &metricsv1.Histogram{
-								DataPoints: []*metricsv1.HistogramDataPoint{
-									makeHistDPNoBuckets(),
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "int_histo",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeIntHistDP(),
+									},
 								},
 							},
 						},
-					},
-				}
-				return []*metricsv1.ResourceMetrics{out}
-			},
-			wantSfxDataPoints: expectedFromHistogram("no_bucket_histo", labelMap, histDPNoBuckets, false),
-		},
-		{
-			name: "summaries",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
-
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "summary",
-						Data: &metricsv1.Metric_Summary{
-							Summary: &metricsv1.Summary{
-								DataPoints: []*metricsv1.SummaryDataPoint{
-									makeSummaryDP(),
+						{
+							Name: "int_delta_histo",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeIntHistDP(),
+									},
 								},
 							},
 						},
-					},
-				}
-				return []*metricsv1.ResourceMetrics{out}
-			},
-			wantSfxDataPoints: expectedFromSummary("summary", labelMap, summaryCountVal, summarySumVal),
-		},
-		{
-			name: "empty_summary",
-			metricsFn: func() []*metricsv1.ResourceMetrics {
-				out := &metricsv1.ResourceMetrics{}
-				ilm := &metricsv1.InstrumentationLibraryMetrics{}
-				out.InstrumentationLibraryMetrics = append(out.InstrumentationLibraryMetrics, ilm)
-
-				ilm.Metrics = []*metricsv1.Metric{
-					{
-						Name: "empty_summary",
-						Data: &metricsv1.Metric_Summary{
-							Summary: &metricsv1.Summary{
-								DataPoints: []*metricsv1.SummaryDataPoint{
-									makeEmptySummaryDP(),
+						{
+							Name: "double_histo",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeDoubleHistDP(),
+									},
 								},
 							},
 						},
+						{
+							Name: "double_delta_histo",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									AggregationTemporality: metricsv1.AggregationTemporality_AGGREGATION_TEMPORALITY_DELTA,
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeDoubleHistDP(),
+									},
+								},
+							},
+						},
+						{
+							Name: "double_histo_bad_counts",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeDoubleHistDPBadCounts(),
+									},
+								},
+							},
+						},
+						{
+							Name: "int_histo_bad_counts",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeIntHistDPBadCounts(),
+									},
+								},
+							},
+						},
+					}
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: mergeDPs(
+					expectedFromHistogram("int_histo", labelMap, intHistDP, false),
+					expectedFromHistogram("int_delta_histo", labelMap, intHistDP, true),
+					expectedFromHistogram("double_histo", labelMap, doubleHistDP, false),
+					expectedFromHistogram("double_delta_histo", labelMap, doubleHistDP, true),
+					[]*datapoint.Datapoint{
+						int64SFxDataPoint("double_histo_bad_counts_count", datapoint.Counter, labelMap, int64(doubleHistDP.Count)),
+						doubleSFxDataPoint("double_histo_bad_counts", datapoint.Counter, labelMap, *doubleHistDP.Sum),
 					},
-				}
-				return []*metricsv1.ResourceMetrics{out}
+					[]*datapoint.Datapoint{
+						int64SFxDataPoint("int_histo_bad_counts_count", datapoint.Counter, labelMap, int64(intHistDP.Count)),
+						doubleSFxDataPoint("int_histo_bad_counts", datapoint.Counter, labelMap, *intHistDP.Sum),
+					},
+				),
 			},
-			wantSfxDataPoints: expectedFromEmptySummary("empty_summary", labelMap, summaryCountVal, summarySumVal),
-		},
-	}
-	for _, tt := range tests {
-		Convey(tt.name, t, func() {
-			rms := tt.metricsFn()
-			gotSfxDataPoints := FromOTLPMetricRequest(&metricsservicev1.ExportMetricsServiceRequest{ResourceMetrics: rms})
-			So(tt.wantSfxDataPoints, ShouldResemble, gotSfxDataPoints)
+			{
+				name: "distribution_no_buckets",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
 
-			dpsFromMetric := FromMetric(rms[0].GetInstrumentationLibraryMetrics()[0].Metrics[0])
-			So(dpsFromMetric, ShouldNotBeEmpty)
-		})
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "no_bucket_histo",
+							Data: &metricsv1.Metric_Histogram{
+								Histogram: &metricsv1.Histogram{
+									DataPoints: []*metricsv1.HistogramDataPoint{
+										makeHistDPNoBuckets(),
+									},
+								},
+							},
+						},
+					}
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: expectedFromHistogram("no_bucket_histo", labelMap, histDPNoBuckets, false),
+			},
+			{
+				name: "summaries",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
+
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "summary",
+							Data: &metricsv1.Metric_Summary{
+								Summary: &metricsv1.Summary{
+									DataPoints: []*metricsv1.SummaryDataPoint{
+										makeSummaryDP(),
+									},
+								},
+							},
+						},
+					}
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: expectedFromSummary("summary", labelMap, summaryCountVal, summarySumVal),
+			},
+			{
+				name: "empty_summary",
+				metricsFn: func() []*metricsv1.ResourceMetrics {
+					out, metrics := createRMS()
+
+					*metrics = []*metricsv1.Metric{
+						{
+							Name: "empty_summary",
+							Data: &metricsv1.Metric_Summary{
+								Summary: &metricsv1.Summary{
+									DataPoints: []*metricsv1.SummaryDataPoint{
+										makeEmptySummaryDP(),
+									},
+								},
+							},
+						},
+					}
+					return []*metricsv1.ResourceMetrics{out}
+				},
+				wantSfxDataPoints: expectedFromEmptySummary("empty_summary", labelMap, summaryCountVal, summarySumVal),
+			},
+		}
+		for _, tt := range tests {
+			Convey(fmt.Sprintf("%s - %v", tt.name, useScopeMetrics), t, func() {
+				rms := tt.metricsFn()
+				gotSfxDataPoints := FromOTLPMetricRequest(&metricsservicev1.ExportMetricsServiceRequest{ResourceMetrics: rms})
+				So(tt.wantSfxDataPoints, ShouldResemble, gotSfxDataPoints)
+
+				var firstMetric *metricsv1.Metric
+				if useScopeMetrics {
+					firstMetric = rms[0].GetScopeMetrics()[0].Metrics[0]
+				} else {
+					firstMetric = rms[0].GetInstrumentationLibraryMetrics()[0].Metrics[0]
+				}
+				dpsFromMetric := FromMetric(firstMetric)
+				So(dpsFromMetric, ShouldNotBeEmpty)
+			})
+		}
 	}
 }
 
@@ -836,3 +845,5 @@ func stringMapToAttributeMap(m map[string]string) []*commonv1.KeyValue {
 	}
 	return ret
 }
+
+func float64Pointer(f float64) *float64 { return &f }


### PR DESCRIPTION
This replaces the use of the deprecated InstrumentationLibraryMetrics.

InstrumentationLibraryMetrics is still looked at for backwards
compatibility but it shouldn't be used anymore by clients.