### PR TITLE
Switch to golang 1.18, allow thrift upgrade to 0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/ingest-protocols
 
-go 1.17
+go 1.18
 
 require (
 	github.com/apache/thrift v0.16.0


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>