### PR TITLE
Upgrade golangci-lint in the github action, too bad we have the version twice

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.1
+          version: v1.49.0
           # Optional: golangci-lint command line arguments.
           args: '--config=.golangci.yml -v'
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>