### PR TITLE
Add single-pass decode APIs for trace ID length hint extraction

### DIFF
--- a/protocol/signalfx/trace_jaeger.go
+++ b/protocol/signalfx/trace_jaeger.go
@@ -72,19 +72,29 @@ type JaegerThriftToSAPMDecoder struct {
 
 // Read reads an http request with a jaeger thrift payload and decodes it into SAPM
 func (j *JaegerThriftToSAPMDecoder) Read(ctx context.Context, req *http.Request) (*splunksapm.PostSpansRequest, error) {
+	sapm, _, err := j.ReadWithRawBatch(ctx, req)
+	return sapm, err
+}
+
+// ReadWithRawBatch decodes a Jaeger Thrift HTTP request in a single pass and returns both the
+// domain-converted SAPM result and the raw *jThrift.Batch. Callers that need raw Thrift fields
+// (e.g. TraceIdHigh/TraceIdLow for trace-ID length hints) can inspect the batch directly without
+// performing a second decode.
+func (j *JaegerThriftToSAPMDecoder) ReadWithRawBatch(ctx context.Context, req *http.Request) (*splunksapm.PostSpansRequest, *jThrift.Batch, error) {
 	batch, err := j.JaegerThriftDecoderBase.Read(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &splunksapm.PostSpansRequest{
+	sapm := &splunksapm.PostSpansRequest{
 		Batches: []*jaegerpb.Batch{
 			{
 				Spans:   toDomain{}.ToDomain(batch.GetSpans(), batch.GetProcess()),
 				Process: toDomain{}.getProcess(batch.GetProcess()),
 			},
 		},
-	}, nil
+	}
+	return sapm, batch, nil
 }
 
 // NewJaegerThriftToSAPMDecoder returns a new JaegerThriftToSAPMDecoder

--- a/protocol/signalfx/trace_jaeger_test.go
+++ b/protocol/signalfx/trace_jaeger_test.go
@@ -252,6 +252,46 @@ const jaegerBatchJSON = `
 }
 `
 
+func TestReadWithRawBatch(t *testing.T) {
+	// Build a thrift batch with two spans: one with zero TraceIdHigh (Long hint) and one with
+	// non-zero TraceIdHigh (Short hint), so we can verify the raw batch is returned intact.
+	highZero := int64(0)
+	highNonZero := int64(1)
+	low := int64(5951113872249657919)
+	rawBatch := &jThrift.Batch{
+		Process: &jThrift.Process{ServiceName: "svc"},
+		Spans: []*jThrift.Span{
+			{TraceIdLow: low, TraceIdHigh: highZero, SpanId: 1, OperationName: "op-long"},
+			{TraceIdLow: low, TraceIdHigh: highNonZero, SpanId: 2, OperationName: "op-short"},
+		},
+	}
+	batchBytes, err := thrift.NewTSerializer().Write(context.Background(), rawBatch)
+	assert.NoError(t, err)
+
+	decoder := NewJaegerThriftToSAPMDecoder()
+
+	t.Run("returns SAPM and raw batch in a single decode pass", func(t *testing.T) {
+		req := &http.Request{Body: ioutil.NopCloser(bytes.NewReader(batchBytes))}
+		sapm, raw, decodeErr := decoder.ReadWithRawBatch(context.Background(), req)
+
+		assert.NoError(t, decodeErr)
+		assert.NotNil(t, sapm)
+		assert.Len(t, sapm.GetBatches(), 1)
+		assert.Len(t, sapm.GetBatches()[0].GetSpans(), 2)
+
+		assert.NotNil(t, raw)
+		assert.Len(t, raw.GetSpans(), 2)
+		assert.Equal(t, highZero, raw.GetSpans()[0].TraceIdHigh)
+		assert.Equal(t, highNonZero, raw.GetSpans()[1].TraceIdHigh)
+	})
+
+	t.Run("returns error on bad body", func(t *testing.T) {
+		req := &http.Request{Body: ioutil.NopCloser(&errorReader{})}
+		_, _, decodeErr := decoder.ReadWithRawBatch(context.Background(), req)
+		assert.EqualError(t, decodeErr, "could not read request body")
+	})
+}
+
 func TestJaegerThriftToSAPMDecoder(t *testing.T) {
 	// test data copied from https://github.com/jaegertracing/jaeger/blob/master/model/converter/thrift/jaeger/fixtures/thrift_batch_01.json
 	jaegerThriftJSON := `

--- a/protocol/signalfx/trace_zipkin.go
+++ b/protocol/signalfx/trace_zipkin.go
@@ -566,7 +566,13 @@ func ParseJaegerSpansFromRequest(req *http.Request) ([]*jaegerpb.Span, error) {
 	if err := easyjson.UnmarshalFromReader(req.Body, &input); err != nil {
 		return nil, ErrInvalidJSONTraceFormat
 	}
+	return ParseJaegerSpansFromInputList(input)
+}
 
+// ParseJaegerSpansFromInputList converts a pre-parsed InputSpanList into jaeger spans.
+// Use this when the caller has already unmarshaled the request body (e.g. to extract trace ID
+// length hints before leading zeros are lost), so the JSON is only decoded once.
+func ParseJaegerSpansFromInputList(input signalfxformat.InputSpanList) ([]*jaegerpb.Span, error) {
 	spans := make([]*jaegerpb.Span, 0, len(input))
 	sm := &spanfilter.Map{}
 

--- a/protocol/signalfx/trace_zipkin_test.go
+++ b/protocol/signalfx/trace_zipkin_test.go
@@ -2402,3 +2402,42 @@ func Test(t *testing.T) {
 	bb, _ := easyjson.Marshal((*signalfxformat.InputSpan)(sourceSpans[0]))
 	require.NotNil(t, bb)
 }
+
+func TestParseJaegerSpansFromInputList(t *testing.T) {
+	t.Run("produces same result as ParseJaegerSpansFromRequest", func(t *testing.T) {
+		body := `[
+			{
+				"traceId": "0123456789abcdef",
+				"id": "abc1234567890def",
+				"name": "op",
+				"kind": "CLIENT",
+				"timestamp": 1000,
+				"duration": 100,
+				"localEndpoint": {"serviceName": "svc"}
+			}
+		]`
+
+		// via ParseJaegerSpansFromRequest
+		reqA := &http.Request{Body: ioutil.NopCloser(strings.NewReader(body))}
+		spansA, errA := ParseJaegerSpansFromRequest(reqA)
+		// ParseJaegerSpansFromRequest returns a *spanfilter.Map as its error; that is not a hard error.
+		assert.True(t, errA == nil || spanfilter.IsMap(errA))
+
+		// via ParseJaegerSpansFromInputList with pre-parsed input
+		var input signalfxformat.InputSpanList
+		require.NoError(t, easyjson.Unmarshal([]byte(body), &input))
+		spansB, errB := ParseJaegerSpansFromInputList(input)
+		assert.True(t, errB == nil || spanfilter.IsMap(errB))
+
+		require.Len(t, spansB, len(spansA))
+		assert.Equal(t, spansA[0].TraceID, spansB[0].TraceID)
+		assert.Equal(t, spansA[0].SpanID, spansB[0].SpanID)
+		assert.Equal(t, spansA[0].OperationName, spansB[0].OperationName)
+	})
+
+	t.Run("empty input returns empty result", func(t *testing.T) {
+		spans, err := ParseJaegerSpansFromInputList(signalfxformat.InputSpanList{})
+		assert.True(t, err == nil || spanfilter.IsMap(err))
+		assert.Empty(t, spans)
+	})
+}


### PR DESCRIPTION
Add ReadWithRawBatch to JaegerThriftToSAPMDecoder, which decodes a Jaeger Thrift request once and returns both the domain-converted SAPM result and the raw *jThrift.Batch. This lets callers inspect TraceIdHigh/TraceIdLow before toDomain collapses them, without a second decode pass.

Add ParseJaegerSpansFromInputList alongside ParseJaegerSpansFromRequest, accepting a pre-parsed InputSpanList so callers that have already unmarshaled the JSON body (e.g. to capture raw trace ID strings before leading zeros are lost) can reuse that parse result instead of re-decoding from bytes.